### PR TITLE
Redirect Pandoc's Output to New Buffer

### DIFF
--- a/Pandoc.py
+++ b/Pandoc.py
@@ -82,13 +82,16 @@ class PandocCommand(sublime_plugin.WindowCommand):
                 subprocess.call(["open", tfname])
             else:
                 sublime.message_dialog('Wrote to file ' + tfname)
+        
         # replace buffer and set syntax
         if result:
-            edit = view.begin_edit()
-            view.replace(edit, region, result.decode('utf8'))
+            w = view.window()
+            w.new_file()
+            edit = w.active_view().begin_edit()
+            w.active_view().replace(edit, region, result.decode('utf8'))
             if 'syntax_file' in format_to:
-                view.set_syntax_file(format_to['syntax_file'])
-            view.end_edit(edit)
+                w.active_view().set_syntax_file(format_to['syntax_file'])
+            w.active_view().end_edit(edit)
         if error:
             sublime.error_message(error)
 


### PR DESCRIPTION
Redirects Pandoc's output to new file buffer. This partially completes issue #2 request.
