### PR TITLE
Added line to open pdf, etc files in Linux.

### DIFF
--- a/Pandoc.py
+++ b/Pandoc.py
@@ -92,6 +92,8 @@ class PandocCommand(sublime_plugin.WindowCommand):
                     subprocess.call(["open", tfname])
                 elif sublime.platform() == 'windows':
                     os.startfile(tfname)
+                elif os.name == 'posix':
+                    subprocess.call(('xdg-open', tfname))
             except:
                 sublime.message_dialog('Wrote to file ' + tfname)
 


### PR DESCRIPTION
'xdg-open' is a freedsktop standard, so it should work largely everywhere.
