### PR TITLE
Add sublime_text version selectors

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7,6 +7,7 @@
       "labels": ["text manipulation", "markdown", "reStructuredText", "pandoc", "markup", "LaTeX"],
       "releases": [
         {
+          "sublime_text": "*",
           "details": "https://github.com/tbfisher/sublimetext-Pandoc/releases"
         }
       ]


### PR DESCRIPTION
We require these now due to the confusion it caused in the past
