### PR TITLE
Replace \r\n with \n when writing to Sublime view

### DIFF
--- a/Pandoc.py
+++ b/Pandoc.py
@@ -170,7 +170,7 @@ class PandocCommand(sublime_plugin.TextCommand):
                 region = sublime.Region(0, view.size())
             else:
                 view = self.view
-            view.replace(edit, region, result.decode('utf8'))
+            view.replace(edit, region, result.decode('utf8').replace('\r\n','\n'))
             view.set_syntax_file(transformation['syntax_file'])
 
 


### PR DESCRIPTION
The Windows version of Pandoc uses Windows-style newlines (`\r\n`) in its output, but Sublime Text expects Unix-style newlines (`\n`). This causes the resulting buffer to be littered with garbage CR characters on Windows.