### PR TITLE
Fix relative paths to images

### DIFF
--- a/Pandoc.py
+++ b/Pandoc.py
@@ -143,7 +143,11 @@ class PandocCommand(sublime_plugin.TextCommand):
         cmd.extend(args)
 
         # run pandoc
-        working_dir = os.path.dirname(self.view.file_name())
+        current_file_path = self.view.file_name()
+        if current_file_path:
+            working_dir = os.path.dirname(current_file_path)
+        else:
+            working_dir = None
         process = subprocess.Popen(
             cmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=working_dir)

--- a/Pandoc.py
+++ b/Pandoc.py
@@ -143,9 +143,10 @@ class PandocCommand(sublime_plugin.TextCommand):
         cmd.extend(args)
 
         # run pandoc
+        working_dir = os.path.dirname(self.view.file_name())
         process = subprocess.Popen(
             cmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE)
+            stderr=subprocess.PIPE, cwd=working_dir)
         result, error = process.communicate(contents.encode('utf-8'))
 
         # handle pandoc errors


### PR DESCRIPTION
Specify the path of the current file as the working directory when executing `pandoc` to allow using relative paths to images. Fixes issue #23.

Unsaved files (without a filename) keep the previous behaviour, i.e. no working directory is defined.