### PR TITLE
Output locally

### DIFF
--- a/Pandoc.py
+++ b/Pandoc.py
@@ -127,12 +127,32 @@ class PandocCommand(sublime_plugin.TextCommand):
             args = args.remove(
                 short=['t', 'w'], long=['to', 'write'], values=['pdf'])
 
+        # output file locally
+        try:
+            transformation['out-local']
+        except:
+            argslocal = None
+        else:
+            argslocal = transformation['out-local']
+
+        # get current file path
+        current_file_path = self.view.file_name()
+        if current_file_path:
+            working_dir = os.path.dirname(current_file_path)
+            file_name = os.path.splitext(current_file_path)[0]
+        else:
+            working_dir = None
+            file_name = None
+
         # if write to file, add -o if necessary, set file path to output_path
         if oformat is not None and oformat in _s('pandoc-format-file'):
             output_path = args.get(short=['o'], long=['output'])
             if output_path is None:
                 # note the file extension matches the pandoc format name
-                output_path = tempfile.NamedTemporaryFile().name
+                if argslocal and file_name:
+                    output_path = file_name
+                else:
+                    output_path = tempfile.NamedTemporaryFile().name
                 # If a specific output format not specified in transformation, default to pandoc format name
                 if oext is None:
                     output_path += "." + oformat
@@ -143,11 +163,6 @@ class PandocCommand(sublime_plugin.TextCommand):
         cmd.extend(args)
 
         # run pandoc
-        current_file_path = self.view.file_name()
-        if current_file_path:
-            working_dir = os.path.dirname(current_file_path)
-        else:
-            working_dir = None
         process = subprocess.Popen(
             cmd, shell=False, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=working_dir)
@@ -186,7 +201,7 @@ class PandocCommand(sublime_plugin.TextCommand):
                 region = sublime.Region(0, view.size())
             else:
                 view = self.view
-            view.replace(edit, region, result.decode('utf8').replace('\r\n','\n'))
+            view.replace(edit, region, result.decode('utf8').replace('\r\n', '\n'))
             view.set_syntax_file(transformation['syntax_file'])
 
 
@@ -247,6 +262,7 @@ def _c(item):
 
 
 class Args(list):
+
     '''Process Pandoc arguments.
 
     "short" are of the form "-k val""".

--- a/Pandoc.sublime-settings
+++ b/Pandoc.sublime-settings
@@ -64,6 +64,9 @@
           "text.html": "html",
           "text.html.markdown": "markdown"
         },
+        // use to place the output in the same directory as the curent file
+        // if -o or --output are set in "pandoc-arguments" this is ignored
+        // "out-local": true,
         "pandoc-arguments": [
           "-t", "pdf"
           // use --latex-engine=engine where engine is
@@ -95,7 +98,7 @@
           "text.html.markdown": "markdown",
           },
         "pandoc-arguments": [
-          "-V", "geometry:margin=1.25in", 
+          "-V", "geometry:margin=1.25in",
           "-s", "--toc", "--number-sections", "--parse-raw",
           "-t", "pdf",
         ],
@@ -147,7 +150,7 @@
           "-t", "beamer",
         ]
       },
-      
+
       "s5 Slides": {
         "scope": {
           "text.html": "html",


### PR DESCRIPTION
Added an option to transformations to automatically output to the same directory with the same name as the current file.

I went with "out-local" as the option name. It doesn't do any checking if the file it would write to already exists.

Should take care of issue #33 
