### PR TITLE
Update `2.x` from `master` so the latest changes can be pulled via Package Control

### DIFF
--- a/Pandoc.py
+++ b/Pandoc.py
@@ -238,6 +238,7 @@ class PandocThread(threading.Thread):
                     region, result.decode('utf8').replace('\r\n', '\n'))
 
             view.set_syntax_file(self.transformation['syntax_file'])
+            view.sel().clear()
 
 
 def _find_binary(name, default=None):

--- a/Pandoc.py
+++ b/Pandoc.py
@@ -88,6 +88,15 @@ class PromptPandocCommand(sublime_plugin.WindowCommand):
         })
 
 
+class BuildPandocCommand(sublime_plugin.WindowCommand):
+
+    def run(self, transformation):
+
+        transformation = _s('transformations')[transformation]
+        self.window.active_view().run_command('pandoc', {'transformation': transformation })
+
+
+
 class PandocCommand(sublime_plugin.TextCommand):
 
     '''Transforms using Pandoc.'''

--- a/Pandoc.sublime-settings
+++ b/Pandoc.sublime-settings
@@ -95,11 +95,11 @@
       "PDF TOC (Narrow margins)": {
         "scope": {
           "text.html": "html",
-          "text.html.markdown": "markdown",
+          "text.html.markdown": "markdown+raw_html",
           },
         "pandoc-arguments": [
           "-V", "geometry:margin=1.25in",
-          "-s", "--toc", "--number-sections", "--parse-raw",
+          "-s", "--toc", "--number-sections",
           "-t", "pdf",
         ],
       },
@@ -107,10 +107,10 @@
       "PDF TOC": {
         "scope": {
           "text.html": "html",
-          "text.html.markdown": "markdown",
+          "text.html.markdown": "markdown+raw_html",
           },
         "pandoc-arguments": [
-          "-s", "--toc", "--number-sections", "--parse-raw",
+          "-s", "--toc", "--number-sections",
           "-t", "pdf",
          ],
       },

--- a/atx-headers-arg-update
+++ b/atx-headers-arg-update
@@ -39,7 +39,7 @@
         "pandoc-arguments": [
           "--to=markdown",
           "--wrap=none",
-          "--atx-headers"
+          "--markdown-headings=atx"
         ]
       },
 

--- a/pandoc.sublime-build
+++ b/pandoc.sublime-build
@@ -1,0 +1,12 @@
+{
+
+	"selector": "text.html.markdown",
+	"target": "build_pandoc",
+	"transformation": "HTML",
+
+	"variants":
+		[
+	    { "name": "Run", "transformation": "PDF" },
+	  ]
+
+}


### PR DESCRIPTION
The last commit to the `2.x` branch was on Apr 22, 2020, so all the changes made to `master` since that time are not yet available to users. This PR brings the branch up to date with master, so that Package Control can pull the latest from the published version at `https://raw.githubusercontent.com/tbfisher/sublimetext-Pandoc/master/packages.json`